### PR TITLE
Graalvm native plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,19 @@ To time the clients:
 Some benchmark results (using `hyperfine --warmup 10 -N <client>`, Kotlin 1.7.10, Java 17 (Intel) and Java 18 (M1),
 GraalVM 22.2.0 (Intel), macOS 12.6 on a M1 machine)
 
-| Client                        | Execution time      | Installation size |
-|-------------------------------|---------------------|-------------------|
-| Java (17 - Intel)             | 108.4 ms ± 2.6 ms   | 16K               |
-| Java (18 - M1)                | 50.6 ms ±   1.0 ms  | -                 |
-| Kotlin/JVM (17 - Intel)       | 112.8 ms ±   4.5 ms | 1.7M              |
-| Kotlin/JVM (18 - M1)          | 52.0 ms ±   1.1 ms  | -                 |
-| Java jlink (17 - Intel)       | 136.9 ms ±   1.7 ms | 43M               |
-| Java GraalVM (22.2.0 - Intel) | 89.1 ms ±   1.0 ms  | 11M               |
-| Java GraalVM (22.2.r11 - M1)  | 5.1 ms ±   0.7 ms   | 12M               |
-| Kotlin/Native (Intel)         | 4.8 ms ±   0.4 ms   | 474K              |
-| Kotlin/Native (M1)            | 1.7 ms ±   0.2 ms   | 473K              |
-| C++ (Intel)                   | 6.8 ms ±   0.5 ms   | 53K               |
+| Client                         | Execution time      | Installation size |
+|--------------------------------|---------------------|-------------------|
+| Java (17 - Intel)              | 108.4 ms ± 2.6 ms   | 16K               |
+| Java (18 - M1)                 | 50.6 ms ±   1.0 ms  | -                 |
+| Kotlin/JVM (17 - Intel)        | 112.8 ms ±   4.5 ms | 1.7M              |
+| Kotlin/JVM (18 - M1)           | 52.0 ms ±   1.1 ms  | -                 |
+| Java jlink (17 - Intel)        | 136.9 ms ±   1.7 ms | 43M               |
+| Java GraalVM (22.2.0 - Intel)  | 89.1 ms ±   1.0 ms  | 11M               |
+| Java GraalVM (22.2.r11 - Intel)| 6.3 ms ±   0.5 ms   | 11.9M             |
+| Java GraalVM (22.2.r11 - M1)   | 5.1 ms ±   0.7 ms   | 12M               |
+| Kotlin/Native (Intel)          | 4.8 ms ±   0.4 ms   | 474K              |
+| Kotlin/Native (M1)             | 1.7 ms ±   0.2 ms   | 473K              |
+| C++ (Intel)                    | 6.8 ms ±   0.5 ms   | 53K               |
 
 #### Older results
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Each client does the same work:
 - Sends a small request message to the server.
 - Receives a small response message from the server.
 
+### Prerequisites
+
+ - GraalVM
+   1. Use SDKMAN to install GraalVM: `$ sdk install java 22.2.r11-grl`
+   2. Point `GRAALVM_HOME` env var to the installation: `$ export GRAALVM_HOME=$SDKMAN_CANDIDATES_DIR/java/22.2.r11-grl`. This step should not be necessary since the `org.graalvm.buildtools.native` plugin [claims](https://graalvm.github.io/native-build-tools/0.9.4/gradle-plugin.html#_installing_graalvm_native_image_tool) it uses toolchains to discover the installation.
+
 To use:
 
 - Run the server using `./gradlew server:run`. This runs in the foreground.
@@ -35,7 +41,7 @@ To time the clients:
 
 - Java: `time ./javaClient/build/install/javaClient/bin/javaClient`
 - Java + jlink: `time ./jlinkClient/build/jlink/bin/client`
-- Java + GraalVM: `time ./graalClient/build/graal`
+- Java + GraalVM: `time ./graalClient/build/native/nativeCompile/graalClient`
 - Kotlin/JVM: `time ./kotlinClient/build/install/kotlinClient/bin/kotlinClient`
 - Kotlin/Native (M1): `time ./kotlinNativeClient/build/bin/macosArm64/releaseExecutable/kotlinNativeClient.kexe`
 - Kotlin/Native (intel): `time ./kotlinNativeClient/build/bin/macosX64/releaseExecutable/kotlinNativeClient.kexe`
@@ -54,6 +60,7 @@ GraalVM 22.2.0 (Intel), macOS 12.6 on a M1 machine)
 | Kotlin/JVM (18 - M1)          | 52.0 ms ±   1.1 ms  | -                 |
 | Java jlink (17 - Intel)       | 136.9 ms ±   1.7 ms | 43M               |
 | Java GraalVM (22.2.0 - Intel) | 89.1 ms ±   1.0 ms  | 11M               |
+| Java GraalVM (22.2.r11 - M1)  | 5.1 ms ±   0.7 ms   | 12M               |
 | Kotlin/Native (Intel)         | 4.8 ms ±   0.4 ms   | 474K              |
 | Kotlin/Native (M1)            | 1.7 ms ±   0.2 ms   | 473K              |
 | C++ (Intel)                   | 6.8 ms ±   0.5 ms   | 53K               |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Each client does the same work:
 
  - GraalVM
    1. Use SDKMAN to install GraalVM: `$ sdk install java 22.2.r11-grl`
-   2. Point `GRAALVM_HOME` env var to the installation: `$ export GRAALVM_HOME=$SDKMAN_CANDIDATES_DIR/java/22.2.r11-grl`. This step should not be necessary since the `org.graalvm.buildtools.native` plugin [claims](https://graalvm.github.io/native-build-tools/0.9.4/gradle-plugin.html#_installing_graalvm_native_image_tool) it uses toolchains to discover the installation.
+   2. Install native image component: `$ $SDKMAN_CANDIDATES_DIR/java/22.2.r11-grl/bin/gu install native-image`
+   3. ~Point `GRAALVM_HOME` env var to the installation: `$ export GRAALVM_HOME=$SDKMAN_CANDIDATES_DIR/java/22.2.r11-grl`. This step should not be necessary since the `org.graalvm.buildtools.native` plugin [claims](https://graalvm.github.io/native-build-tools/0.9.4/gradle-plugin.html#_installing_graalvm_native_image_tool) it uses toolchains to discover the installation.~
 
 To use:
 

--- a/graalClient/build.gradle
+++ b/graalClient/build.gradle
@@ -1,40 +1,28 @@
+import org.graalvm.buildtools.gradle.tasks.NativeRunTask
+
 plugins {
-    id "base"
+    id 'application'
+    id 'org.graalvm.buildtools.native' version '0.9.14'
 }
 
-configurations {
-    implementation {}
+application {
+    mainClass = 'net.rubygrapefruit.java.JavaClient'
 }
 
 dependencies {
-    implementation project(':javaClient')
+    nativeImageClasspath project(':javaClient')
 }
 
-task graalImage {
-    ext.outputFile = objects.fileProperty()
-    outputFile.set(layout.buildDirectory.file("graal"))
-    inputs.files configurations.implementation
-    outputs.file outputFile
-    doLast {
-        delete outputFile.get()
-        exec {
-            commandLine = [new File(System.getProperty("user.home"), "bin/downloads/graalvm-amd64-22.2/graalvm-ce-java11-22.2.0/Contents/Home/bin/native-image").absolutePath, "-cp", configurations.implementation.asPath, "net.rubygrapefruit.java.JavaClient", outputFile.get().asFile.absolutePath]
-        }
-    }
+nativeBuild {
+    runtimeArgs "registryRoot=${rootProject.projectDir.absolutePath}"
 }
 
-assemble.dependsOn graalImage
-
-task runGraal {
-    dependsOn graalImage
-    doLast {
-        exec {
-            workingDir = ".."
-            commandLine = graalImage.outputFile.get().asFile
-        }
+tasks.named('nativeRun', NativeRunTask) {
+    doFirst {
+        logger.lifecycle "runtimeArgs: {}", runtimeArgs.get()
     }
 }
 
 task runClient {
-    dependsOn runGraal
+    dependsOn nativeRun
 }

--- a/javaClient/src/main/java/net/rubygrapefruit/java/JavaClient.java
+++ b/javaClient/src/main/java/net/rubygrapefruit/java/JavaClient.java
@@ -13,13 +13,22 @@ import java.nio.file.Paths;
 public class JavaClient {
     public static void main(String[] args) throws IOException {
         System.out.println("* Java client");
-        int port = readServerPort();
+        String registryRootPath = maybeGetRegistryRoot(args);
+        int port = readServerPort(registryRootPath);
         System.out.println(String.format("* Server port: %s", port));
         handleRequest(port);
     }
 
-    private static int readServerPort() throws IOException {
-        Path registryFile = Paths.get("build/server.bin");
+    private static String maybeGetRegistryRoot(String[] args) {
+        final String registryRoot = "registryRoot";
+        if (args.length == 1 && args[0].startsWith(registryRoot)) {
+            return args[0].split("=")[1];
+        }
+        return "";
+    }
+
+    private static int readServerPort(String registryRootPath) throws IOException {
+        Path registryFile = Paths.get(registryRootPath, "build/server.bin");
         try (InputStream registryStream = Files.newInputStream(registryFile)) {
             int b1 = registryStream.read();
             int b2 = registryStream.read();

--- a/kotlinClient/build.gradle
+++ b/kotlinClient/build.gradle
@@ -5,10 +5,6 @@ plugins {
 
 mainClassName = "net.rubygrapefruit.kotlin.KotlinClientKt"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }

--- a/kotlinNativeClient/build.gradle
+++ b/kotlinNativeClient/build.gradle
@@ -17,10 +17,6 @@ kotlin {
     }
 }
 
-repositories {
-    mavenCentral()
-}
-
 runReleaseExecutableMacosArm64 {
     workingDir = ".."
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
 
 include("server")
 include("javaClient")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()


### PR DESCRIPTION
Replaces hand-rolled graalvm client assembly with "official" tooling.

Note that performance is now very similar to Kotlin/Native though native binaries are still relatively large at ~12MB.